### PR TITLE
feat: video options for various devices

### DIFF
--- a/mock_ai/components/VideoRecorder.tsx
+++ b/mock_ai/components/VideoRecorder.tsx
@@ -235,12 +235,16 @@ export default function VideoRecorder({
                   </p>
                 </div>
               )}
-              <div className="aspect-w-16 aspect-h-9 bg-[#131538] rounded-lg overflow-hidden max-w-full">
+              <div className="relative w-full aspect-w-16 aspect-h-9 md:aspect-w-4 md:aspect-h-3 bg-[#131538] rounded-lg overflow-hidden ">
                 <video
                   ref={videoRef}
                   key={videoUrl}
                   className="w-full h-full object-cover"
                   controls
+                  playsInline
+                  webkit-playsinline="true"
+                  disablePictureInPicture={true}
+                  controlsList="nodownload nofullscreen noremoteplayback"
                   muted
                   crossOrigin="anonymous"
                 >


### PR DESCRIPTION
This pull request includes changes to the `VideoRecorder` component in `mock_ai/components/VideoRecorder.tsx` to improve the video display and control functionality. The most important changes include adjustments to the aspect ratio settings and enhancements to the video control attributes.

Improvements to video display and control:

* Modified the `div` containing the video element to use a responsive aspect ratio for different screen sizes by adding `md:aspect-w-4 md:aspect-h-3` classes.
* Added several attributes to the `video` element to enhance user experience: `playsInline`, `webkit-playsinline="true"`, `disablePictureInPicture={true}`, and `controlsList="nodownload nofullscreen noremoteplayback"`.