### PR TITLE
feat: implement interview cancellation handling and improve step prog…

### DIFF
--- a/mock_ai/components/VideoRecorder.tsx
+++ b/mock_ai/components/VideoRecorder.tsx
@@ -17,6 +17,7 @@ interface VideoRecorderProps {
   user: User;
   onUploadStatusChange: (status: boolean) => void;
   interviewData: InterviewData;
+  isInterviewCanceled: boolean;
 }
 
 export default function VideoRecorder({
@@ -25,6 +26,7 @@ export default function VideoRecorder({
   user,
   onUploadStatusChange,
   interviewData,
+  isInterviewCanceled,
 }: VideoRecorderProps) {
   const [isDeviceDesktop, setIsDeviceDesktop] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -142,20 +144,21 @@ export default function VideoRecorder({
 
   useEffect(() => {
     const uploadBlobs = async () => {
-      if (videoBlob && audioBlob) {
-        try {
-          await handleUploadAudio(
-            interviewData,
-            user,
-            selectedQuestion,
-            questionId
-          ); // Upload extracted audio
-          onUploadStatusChange(true);
-          videoRef.current?.scrollIntoView({ behavior: "smooth" });
-        } catch (error) {
-          console.error("Error uploading blobs:", error);
-          onUploadStatusChange(false);
-        }
+      if (isInterviewCanceled) {
+        return;
+      }
+      try {
+        await handleUploadAudio(
+          interviewData,
+          user,
+          selectedQuestion,
+          questionId
+        ); // Upload extracted audio
+        onUploadStatusChange(true);
+        videoRef.current?.scrollIntoView({ behavior: "smooth" });
+      } catch (error) {
+        console.error("Error uploading blobs:", error);
+        onUploadStatusChange(false);
       }
     };
 
@@ -171,6 +174,7 @@ export default function VideoRecorder({
     questionId,
     onUploadStatusChange,
     interviewData,
+    isInterviewCanceled,
   ]);
 
   useEffect(() => {

--- a/mock_ai/components/step-progress.tsx
+++ b/mock_ai/components/step-progress.tsx
@@ -34,6 +34,7 @@ export default function StepProgress({
           {steps.map((step, index) => {
             const isCompleted = currentStep > index;
             const isCurrent = currentStep === index;
+            const isFinished = currentStep === steps.length - 1;
 
             return (
               <div
@@ -84,7 +85,9 @@ export default function StepProgress({
                         : "text-[#f0f0f0]"
                     )}
                   >
-                    {step.label}
+                    {isFinished && step.id === "start interview"
+                      ? step.message
+                      : step.label}
                   </span>
                 </div>
 


### PR DESCRIPTION
This pull request introduces several changes to the `mock_ai/components/Interview.tsx` and related files to improve the interview experience by handling interview cancellations and updating the step progress display. The most important changes include adding cancellation functionality, updating the step progress display, and ensuring components handle the new cancellation state appropriately.

Enhancements to interview cancellation:

* [`mock_ai/components/Interview.tsx`](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R100-R103): Added state variables `controller` and `isInterviewCanceled` to manage interview cancellation. Updated the `fetchQuestion` function to respect the cancellation state and abort ongoing requests if necessary. Implemented the `handleQuitInterview` function to handle interview quitting and reset the state. [[1]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R100-R103) [[2]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R158-R165) [[3]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R178) [[4]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R194-R196) [[5]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R214-R217) [[6]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R228-R239)

* [`mock_ai/components/VideoRecorder.tsx`](diffhunk://#diff-0e1824812bcbdda4b83870e188a8e99170935fdbbe8add6d85d46d934c927a57R20): Added `isInterviewCanceled` prop to handle the cancellation state and prevent unnecessary uploads when the interview is canceled. [[1]](diffhunk://#diff-0e1824812bcbdda4b83870e188a8e99170935fdbbe8add6d85d46d934c927a57R20) [[2]](diffhunk://#diff-0e1824812bcbdda4b83870e188a8e99170935fdbbe8add6d85d46d934c927a57R29) [[3]](diffhunk://#diff-0e1824812bcbdda4b83870e188a8e99170935fdbbe8add6d85d46d934c927a57L145-R149) [[4]](diffhunk://#diff-0e1824812bcbdda4b83870e188a8e99170935fdbbe8add6d85d46d934c927a57L159) [[5]](diffhunk://#diff-0e1824812bcbdda4b83870e188a8e99170935fdbbe8add6d85d46d934c927a57R177)

Updates to step progress display:

* [`mock_ai/components/step-progress.tsx`](diffhunk://#diff-925421fd31a83893450ef810a9cc6965999a164ac1c93e0b31dde8b757625292R37): Introduced `isFinished` variable to display a custom message when the interview is completed. [[1]](diffhunk://#diff-925421fd31a83893450ef810a9cc6965999a164ac1c93e0b31dde8b757625292R37) [[2]](diffhunk://#diff-925421fd31a83893450ef810a9cc6965999a164ac1c93e0b31dde8b757625292L87-R90)

Minor adjustments:

* [`mock_ai/components/Interview.tsx`](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R83): Added a message to the "Start Interview" step and updated the display logic to hide the reset button on the first step. [[1]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R83) [[2]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R347) [[3]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R357-R358)

* [`mock_ai/components/Interview.tsx`](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461L295-R319): Ensured that the `selectedQuestion` is not displayed when the interview is canceled. [[1]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461L295-R319) [[2]](diffhunk://#diff-9e1f44423cf5e6f0f8822f9aa8161525abf137627a57b635bf0e38f5abdeb461R337)…ress messaging